### PR TITLE
feat(vehicle): TESLA_COMMANDS_DRY_RUN safety guard for commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ TESLA_FLEET_API_URL=https://proxy.teslapp.feyli.dev
 
 # Sodium key (base64 of 32 bytes) used to encrypt the OAuth tokens stored in oauth2_token.
 TESLAPP_TOKEN_ENCRYPTION_KEY=
+
+# Vehicle command safety guard (issue #26). true (default) = commands are logged
+# and simulated, NOT sent to the real vehicle. Set to false ONLY for an in-person
+# test with the virtual key paired on the car.
+TESLA_COMMANDS_DRY_RUN=true

--- a/private/Models/Shared/TeslaApi/TeslaCommandClient.php
+++ b/private/Models/Shared/TeslaApi/TeslaCommandClient.php
@@ -18,51 +18,75 @@ use Teslapp\Models\Shared\ValueObjects\Vin;
  *
  * The user access token is resolved by TeslaHttpClient (from the session), so it
  * is not passed to these methods.
+ *
+ * SAFETY: while $dryRun is true (the default, wired from TESLA_COMMANDS_DRY_RUN),
+ * no command is actually sent — see send(). This prevents accidental real commands
+ * on a paired vehicle from a deployed environment.
  */
 final readonly class TeslaCommandClient implements VehicleCommandClient
 {
-    public function __construct() {}
+    public function __construct(private bool $dryRun = true) {}
 
     public function lock(Vin $vin): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/door_lock");
+        $this->send("/api/1/vehicles/{$vin->value}/command/door_lock");
     }
 
     public function unlock(Vin $vin): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/door_unlock");
+        $this->send("/api/1/vehicles/{$vin->value}/command/door_unlock");
     }
 
     public function honkHorn(Vin $vin): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/honk_horn");
+        $this->send("/api/1/vehicles/{$vin->value}/command/honk_horn");
     }
 
     public function flashLights(Vin $vin): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/flash_lights");
+        $this->send("/api/1/vehicles/{$vin->value}/command/flash_lights");
     }
 
     public function actuateTrunk(Vin $vin, TrunkSide $side): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/actuate_trunk", [
+        $this->send("/api/1/vehicles/{$vin->value}/command/actuate_trunk", [
             'which_trunk' => $side->value,
         ]);
     }
 
     public function openChargePortDoor(Vin $vin): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/charge_port_door_open");
+        $this->send("/api/1/vehicles/{$vin->value}/command/charge_port_door_open");
     }
 
     public function closeChargePortDoor(Vin $vin): void
     {
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/command/charge_port_door_close");
+        $this->send("/api/1/vehicles/{$vin->value}/command/charge_port_door_close");
     }
 
     public function wakeUp(Vin $vin): void
     {
         // wake_up is a vehicle endpoint, not a signed command: no /command/ segment.
-        TeslaHttpClient::post("/api/1/vehicles/{$vin->value}/wake_up");
+        $this->send("/api/1/vehicles/{$vin->value}/wake_up");
+    }
+
+    /**
+     * Sends a command to the Fleet API, unless the dry-run guard is active.
+     *
+     * In dry-run (TESLA_COMMANDS_DRY_RUN=true, the default) the command is logged
+     * and skipped so the UI keeps working without touching a real vehicle. Flip the
+     * flag to false only for an in-person test with the virtual key paired.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function send(string $path, array $body = []): void
+    {
+        if ($this->dryRun) {
+            error_log("TESLA_COMMANDS_DRY_RUN active — command not sent: {$path}");
+
+            return;
+        }
+
+        TeslaHttpClient::post($path, $body);
     }
 }

--- a/private/config/config.php
+++ b/private/config/config.php
@@ -96,3 +96,21 @@ define('TESLA_FIXTURES_PATH', getenv('TESLA_FIXTURES_PATH') ?: BASE_PATH . 'test
  * seeded by db/script_insertion_dev.sql.
  */
 define('DEV_USER_ID', getenv('DEV_USER_ID') ?: '00000000-0000-0000-0000-000000000001');
+
+/**
+ * Safety guard for vehicle commands (issue #26). When true (the default),
+ * TeslaCommandClient does NOT send commands to the Fleet API / proxy — it logs
+ * and simulates success. Set to false ONLY once the virtual key is paired on the
+ * real vehicle (in-person test). Prevents accidental real commands on the
+ * professor's Tesla from a deployed environment.
+ *
+ * Fail-safe: a missing, empty or invalid value falls back to true (blocked).
+ * Only an explicit falsy value (false/0/off/no) turns the guard off.
+ */
+$dryRunRaw = getenv('TESLA_COMMANDS_DRY_RUN');
+define(
+    'TESLA_COMMANDS_DRY_RUN',
+    $dryRunRaw === false || $dryRunRaw === ''
+        ? true
+        : (filter_var($dryRunRaw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true),
+);

--- a/private/config/config.php
+++ b/private/config/config.php
@@ -112,5 +112,5 @@ define(
     'TESLA_COMMANDS_DRY_RUN',
     $dryRunRaw === false || $dryRunRaw === ''
         ? true
-        : (filter_var($dryRunRaw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true),
+        : filter_var($dryRunRaw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true,
 );

--- a/private/config/container.php
+++ b/private/config/container.php
@@ -78,7 +78,7 @@ $container->set(
 // Vehicle commands (issue #26): command port -> adapter, then service and controller.
 $container->set(
     VehicleCommandClient::class,
-    static fn(): VehicleCommandClient => new TeslaCommandClient(),
+    static fn(): VehicleCommandClient => new TeslaCommandClient(TESLA_COMMANDS_DRY_RUN),
 );
 $container->set(
     VehicleCommandService::class,

--- a/tests/Unit/Models/Shared/TeslaApi/TeslaCommandClientTest.php
+++ b/tests/Unit/Models/Shared/TeslaApi/TeslaCommandClientTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Teslapp\Tests\Unit\Models\Shared\TeslaApi;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Teslapp\Models\Shared\Exceptions\TeslaApiException;
+use Teslapp\Models\Shared\TeslaApi\TeslaCommandClient;
+use Teslapp\Models\Shared\ValueObjects\Vin;
+
+/**
+ * Covers the TESLA_COMMANDS_DRY_RUN safety guard of TeslaCommandClient.
+ *
+ * The adapter itself is not otherwise unit-tested (the VehicleCommandClient port
+ * is mocked elsewhere); only the guard — which decides whether a real command is
+ * sent — is exercised here.
+ */
+#[CoversClass(TeslaCommandClient::class)]
+final class TeslaCommandClientTest extends TestCase
+{
+    private const VIN = '5YJ3E1EA7KF000316';
+
+    protected function setUp(): void
+    {
+        // No authenticated session: TeslaHttpClient would have no user token.
+        $_SESSION = [];
+    }
+
+    #[Test]
+    public function dryRunDoesNotSendTheCommand(): void
+    {
+        $client = new TeslaCommandClient(dryRun: true);
+
+        // Guard active: send() returns before any HTTP call, so no token is needed
+        // and no exception is thrown (the command is simulated, not sent).
+        $client->lock(new Vin(self::VIN));
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function withoutDryRunItReachesTheHttpCall(): void
+    {
+        $client = new TeslaCommandClient(dryRun: false);
+
+        // Guard off: send() calls TeslaHttpClient::post, which needs a user token
+        // from the session. There is none, so it throws before any network call —
+        // proving the real-command path is taken when the guard is disabled.
+        $this->expectException(TeslaApiException::class);
+
+        $client->lock(new Vin(self::VIN));
+    }
+}


### PR DESCRIPTION
## Summary
- Add a TESLA_COMMANDS_DRY_RUN safety guard (issue #26 follow-up). When on (the default), TeslaCommandClient logs and skips commands instead of sending them to the Fleet API/proxy, so the UI works without touching a real vehicle.
- Read from the environment, fail-safe to "blocked" on a missing/empty/invalid value; only an explicit falsy value disables it.
- Flip to false only for an in-person test once the virtual key is paired.

## Test plan
- `composer phpstan` → 0 errors
- `composer test` → 73 tests pass (new TeslaCommandClientTest covers both guard states)
