### PR TITLE
Dashboard & vehicle commands UI redesign

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -551,7 +551,7 @@ input:focus-visible {
 
 .footer {
   padding: 48px 0 0;
-  background-color: var(--color-bg-card);
+  background-color: var(--color-bg);
   border-top: 0.667px solid var(--color-border);
 }
 

--- a/private/Views/Vehicle/control.php
+++ b/private/Views/Vehicle/control.php
@@ -1,8 +1,12 @@
 <?php
 /**
  * Vehicle command page — the "Véhicule" dashboard tab (issue #26).
- * Hosts the remote command buttons; each button POSTs to /vehicle/<action>
- * (handled by VehicleCommandController), VIN resolved server-side from session.
+ * A primary "wake" banner on top, then remote command tiles grouped by
+ * category. Each wired control (the hero + every tile) is a <button data-action>
+ * that POSTs to /vehicle/<action> (handled by VehicleCommandController); the VIN
+ * is resolved server-side from the session. The JS (vehicle-actions.js) toggles
+ * an .is-loading class and writes the shared [data-action-feedback] element — it
+ * never rewrites a button's content, so the SVG pictograms are preserved.
  */
 $title = 'Commandes du véhicule — TeslApp';
 $description = 'Commandes à distance de votre véhicule Tesla : verrouillage, klaxon, coffres et trappe de charge.';
@@ -19,25 +23,114 @@ ob_start();
       <main class="dashboard-content">
         <h1 class="dashboard-title">Commandes du véhicule</h1>
 
-        <!-- Actions (vehicle commands, issue #26) -->
-        <div class="dashboard-actions">
-          <h2 class="dashboard-actions-title">Actions disponibles</h2>
-          <div class="actions-grid">
-            <button class="action-btn" type="button" data-action="lock">Verrouiller</button>
-            <button class="action-btn" type="button" data-action="unlock">Déverrouiller</button>
-            <button class="action-btn" type="button" data-action="honk">Klaxon</button>
-            <button class="action-btn" type="button" data-action="flash">Appel de phares</button>
-            <button class="action-btn" type="button" data-action="trunk-front">Coffre avant</button>
-            <button class="action-btn" type="button" data-action="trunk-rear">Coffre arrière</button>
-            <button class="action-btn" type="button" data-action="charge-port-open">Ouvrir la trappe de charge</button>
-            <button class="action-btn" type="button" data-action="charge-port-close">Fermer la trappe de charge</button>
-            <button class="action-btn" type="button" data-action="wake">Réveiller</button>
-            <!-- Owned by other issues (battery #25, climate #28, location #32) — left disabled -->
-            <button class="action-btn" type="button" disabled>Batterie</button>
-            <button class="action-btn" type="button" disabled>Climatisation</button>
-            <button class="action-btn" type="button" disabled>Localisation</button>
-          </div>
-          <p class="actions-feedback" role="status" aria-live="polite" data-action-feedback></p>
+        <p class="actions-feedback" role="status" aria-live="polite" data-action-feedback></p>
+
+        <div class="vehicle-commands">
+          <!-- Primary action: wake the vehicle -->
+          <button class="command-hero" type="button" data-action="wake">
+            <span class="command-hero__icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M5.636 5.636a9 9 0 1 0 12.728 0M12 3v9" />
+              </svg>
+            </span>
+            <span class="command-hero__text">
+              <span class="command-hero__title">Réveiller le véhicule</span>
+              <span class="command-hero__hint">À lancer avant une commande si la voiture est en veille</span>
+            </span>
+          </button>
+
+          <!-- Accès & sécurité -->
+          <section class="command-group">
+            <h2 class="command-group__title">Accès &amp; sécurité</h2>
+            <div class="command-grid">
+              <button class="command-card" type="button" data-action="lock">
+                <span class="command-card__icon command-card__icon--access">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Verrouiller</span>
+              </button>
+              <button class="command-card" type="button" data-action="unlock">
+                <span class="command-card__icon command-card__icon--access">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Déverrouiller</span>
+              </button>
+            </div>
+          </section>
+
+          <!-- Coffres -->
+          <section class="command-group">
+            <h2 class="command-group__title">Coffres</h2>
+            <div class="command-grid">
+              <button class="command-card" type="button" data-action="trunk-front">
+                <span class="command-card__icon command-card__icon--trunk">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Coffre avant</span>
+              </button>
+              <button class="command-card" type="button" data-action="trunk-rear">
+                <span class="command-card__icon command-card__icon--trunk">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Coffre arrière</span>
+              </button>
+            </div>
+          </section>
+
+          <!-- Recharge -->
+          <section class="command-group">
+            <h2 class="command-group__title">Recharge</h2>
+            <div class="command-grid">
+              <button class="command-card" type="button" data-action="charge-port-open">
+                <span class="command-card__icon command-card__icon--charge">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Ouvrir la trappe</span>
+              </button>
+              <button class="command-card" type="button" data-action="charge-port-close">
+                <span class="command-card__icon command-card__icon--charge">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z" />
+                    <path d="M3 3l18 18" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Fermer la trappe</span>
+              </button>
+            </div>
+          </section>
+
+          <!-- Signalement -->
+          <section class="command-group">
+            <h2 class="command-group__title">Signalement</h2>
+            <div class="command-grid">
+              <button class="command-card" type="button" data-action="honk">
+                <span class="command-card__icon command-card__icon--signal">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M19.114 5.636a9 9 0 0 1 0 12.728M16.463 8.288a5.25 5.25 0 0 1 0 7.424M6.75 8.25l4.72-4.72a.75.75 0 0 1 1.28.53v15.88a.75.75 0 0 1-1.28.53l-4.72-4.72H4.51c-.88 0-1.704-.507-1.938-1.354A9.011 9.011 0 0 1 2.25 12c0-.83.112-1.633.322-2.395C2.806 8.755 3.63 8.25 4.51 8.25H6.75Z" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Klaxon</span>
+              </button>
+              <button class="command-card" type="button" data-action="flash">
+                <span class="command-card__icon command-card__icon--signal">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 18v-5.25m0 0a6.01 6.01 0 0 0 1.5-.189m-1.5.189a6.01 6.01 0 0 1-1.5-.189m3.75 7.478a12.06 12.06 0 0 1-4.5 0m3.75 2.355a14.4 14.4 0 0 1-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 1 0-7.517 0c.85.493 1.509 1.333 1.509 2.316V18" />
+                  </svg>
+                </span>
+                <span class="command-card__label">Appel de phares</span>
+              </button>
+            </div>
+          </section>
         </div>
 
         <p class="dashboard-change-vehicle">

--- a/private/Views/Vehicle/control.php
+++ b/private/Views/Vehicle/control.php
@@ -21,7 +21,15 @@ ob_start();
       <?php $activeNav = 'vehicle'; require __DIR__ . '/../partials/dashboard_nav.php'; ?>
 
       <main class="dashboard-content">
-        <h1 class="dashboard-title">Commandes du véhicule</h1>
+        <header class="commands-header">
+          <h1 class="dashboard-title">Commandes du véhicule</h1>
+          <a href="/vehicle/select" class="btn-switch-vehicle">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+            </svg>
+            Changer de véhicule
+          </a>
+        </header>
 
         <p class="actions-feedback" role="status" aria-live="polite" data-action-feedback></p>
 
@@ -132,10 +140,6 @@ ob_start();
             </div>
           </section>
         </div>
-
-        <p class="dashboard-change-vehicle">
-          <a href="/vehicle/select">Changer de véhicule</a>
-        </p>
       </main>
     </div>
   </section>

--- a/www/_assets/css/dashboard.css
+++ b/www/_assets/css/dashboard.css
@@ -7,6 +7,7 @@
   display: grid;
   grid-template-columns: auto 1fr;
   min-height: calc(100vh - 64px);
+  background-color: var(--color-bg-secondary);
 }
 
 /* Left Nav — floating sticky card */

--- a/www/_assets/css/dashboard.css
+++ b/www/_assets/css/dashboard.css
@@ -5,31 +5,40 @@
 /* Layout */
 .dashboard-layout {
   display: grid;
-  grid-template-columns: 100px 1fr;
+  grid-template-columns: auto 1fr;
   min-height: calc(100vh - 64px);
 }
 
-/* Left Nav */
+/* Left Nav — floating sticky card */
 .dashboard-navigation {
+  position: sticky;
+  top: 80px; /* sticky header (64px) + 16px breathing space */
+  align-self: start; /* don't stretch to full row height -> enables sticky */
+  z-index: 10; /* above content, below the header (z-index 1000) */
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 24px 8px;
+  gap: 6px;
+  width: 92px;
+  margin: 16px; /* gaps: header (top), footer (bottom), edges (left/right) */
+  padding: 14px 8px;
   background-color: var(--color-bg-card);
-  border-right: 1px solid var(--color-border);
+  border: 1px solid var(--color-border);
+  border-radius: 22px;
+  box-shadow: var(--shadow-lg);
 }
 
 .nav-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
-  padding: 12px 8px;
+  gap: 5px;
+  padding: 10px 6px;
   width: 100%;
-  border-radius: 12px;
+  border-radius: 14px;
   cursor: pointer;
   text-decoration: none;
+  transition: background-color 0.15s ease;
 }
 
 .nav-item:hover {
@@ -40,8 +49,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
 }
 
@@ -204,8 +213,8 @@
 
 /* Responsive */
 @media (max-width: 1024px) {
-  .dashboard-layout {
-    grid-template-columns: 80px 1fr;
+  .dashboard-navigation {
+    width: 84px;
   }
 }
 
@@ -216,11 +225,26 @@
   }
 
   .dashboard-navigation {
+    position: sticky;
+    top: 76px; /* sticky header (64px) + 12px breathing space */
+    z-index: 100;
     flex-direction: row;
     justify-content: space-around;
-    padding: 12px;
-    border-right: none;
-    border-bottom: 1px solid var(--color-border);
+    gap: 4px;
+    width: auto;
+    margin: 12px;
+    padding: 8px 6px;
+    border: 1px solid var(--color-border);
+    border-radius: 18px;
+  }
+
+  .dashboard-navigation .nav-item {
+    padding: 6px 4px;
+  }
+
+  .dashboard-navigation .nav-item__icon {
+    width: 34px;
+    height: 34px;
   }
 
   .dashboard-content {

--- a/www/_assets/css/dashboard.css
+++ b/www/_assets/css/dashboard.css
@@ -22,7 +22,7 @@
   width: 92px;
   margin: 16px; /* gaps: header (top), footer (bottom), edges (left/right) */
   padding: 14px 8px;
-  background-color: var(--color-bg-card);
+  background-color: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: 22px;
   box-shadow: var(--shadow-lg);

--- a/www/_assets/css/vehicle-actions.css
+++ b/www/_assets/css/vehicle-actions.css
@@ -8,9 +8,52 @@
  * rewrites a button's content, so the pictograms survive.
  */
 
-/* Tighten the title gap on this page (the empty feedback line sits just below). */
-.dashboard-content .dashboard-title {
+/* Page header: title + secondary "switch vehicle" action. */
+.commands-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 16px;
   margin-bottom: 20px;
+}
+
+.commands-header .dashboard-title {
+  margin-bottom: 0;
+}
+
+.btn-switch-vehicle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.btn-switch-vehicle:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-hover);
+}
+
+.btn-switch-vehicle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.btn-switch-vehicle svg {
+  width: 16px;
+  height: 16px;
 }
 
 /* --- Feedback banner (aria-live, kept in flow to avoid layout shift) --- */

--- a/www/_assets/css/vehicle-actions.css
+++ b/www/_assets/css/vehicle-actions.css
@@ -219,8 +219,15 @@
 }
 
 .command-card__label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Reserve 2 lines so 1-line and 2-line labels yield the same tile height. */
+  min-height: 2.6em;
   font-size: 13.5px;
   font-weight: 500;
+  line-height: 1.3;
+  text-align: center;
 }
 
 /* --- Icon tints per category (mirrors the sidebar nav palette) --- */

--- a/www/_assets/css/vehicle-actions.css
+++ b/www/_assets/css/vehicle-actions.css
@@ -1,104 +1,22 @@
-/* vehicle-actions.css — styles for the issue #26 command buttons.
+/* vehicle-actions.css — issue #26 vehicle command UI.
  *
- * Base layout (.dashboard-actions, .actions-grid, .action-btn) originally lived
- * in dashboard.css (issue #25), but development's dashboard rewrite (sidebar
- * layout) dropped those classes. They are re-added here, scoped to #26, so the
- * action grid renders without touching development's dashboard.css.
- *
- * The base .action-btn is a disabled "coming soon" placeholder (cursor:
- * not-allowed; opacity: 0.5); the .action-btn[data-action] rules below give the
- * wired buttons a clickable look. Buttons without data-action (battery, climate,
- * location) keep the placeholder look.
+ * Layout: a full-width primary "wake" banner (.command-hero) followed by four
+ * categories (.command-group) of command tiles (.command-card), each an SVG
+ * pictogram in a tinted circle + a label, reusing the dashboard/sidebar visual
+ * language. The JS (vehicle-actions.js) toggles the .is-loading class during a
+ * command and writes the shared [data-action-feedback] element — it never
+ * rewrites a button's content, so the pictograms survive.
  */
 
-/* --- Base layout (rapatriated from dashboard.css #25) --- */
-.dashboard-actions {
-  padding: 32px;
-  background-color: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 14px;
-  box-shadow: var(--shadow-card);
+/* Tighten the title gap on this page (the empty feedback line sits just below). */
+.dashboard-content .dashboard-title {
+  margin-bottom: 20px;
 }
 
-.dashboard-actions-title {
-  margin-bottom: 24px;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.actions-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 12px;
-}
-
-.action-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 12px 16px;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  background-color: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-@media (max-width: 1024px) {
-  .actions-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (max-width: 768px) {
-  .actions-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .dashboard-actions {
-    padding: 24px;
-  }
-}
-
-@media (max-width: 480px) {
-  .actions-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* --- Interactive state for wired buttons --- */
-.action-btn[data-action] {
-  color: var(--color-text);
-  cursor: pointer;
-  opacity: 1;
-  transition:
-    border-color 0.15s ease,
-    background-color 0.15s ease,
-    transform 0.05s ease;
-}
-
-.action-btn[data-action]:hover {
-  border-color: var(--color-primary);
-  background-color: var(--color-bg-card);
-}
-
-.action-btn[data-action]:active {
-  transform: translateY(1px);
-}
-
-/* While a command is in flight the JS disables the button. */
-.action-btn[data-action]:disabled {
-  cursor: progress;
-  opacity: 0.6;
-}
-
+/* --- Feedback banner (aria-live, kept in flow to avoid layout shift) --- */
 .actions-feedback {
-  margin-top: 16px;
   min-height: 1.25rem;
+  margin-bottom: 12px;
   font-size: 14px;
   color: var(--color-text-secondary);
 }
@@ -109,4 +27,223 @@
 
 .actions-feedback[data-state='error'] {
   color: var(--color-error);
+}
+
+/* --- Command panel: hero (full width) + 4 category columns --- */
+.vehicle-commands {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px 20px;
+  align-items: start;
+}
+
+/* --- Primary action: wake the vehicle (full-width banner) --- */
+.command-hero {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px 24px;
+  font-family: inherit;
+  text-align: left;
+  color: var(--color-text);
+  background-color: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.08s ease;
+}
+
+.command-hero:hover {
+  border-color: var(--color-border-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.command-hero:active {
+  transform: translateY(1px);
+}
+
+.command-hero:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.command-hero.is-loading {
+  cursor: progress;
+  opacity: 0.6;
+}
+
+.command-hero__icon {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background-color: rgba(33, 150, 232, 0.15);
+  color: #2196e8;
+}
+
+.command-hero__icon svg {
+  width: 26px;
+  height: 26px;
+}
+
+.command-hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.command-hero__title {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.command-hero__hint {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+/* --- Category --- */
+.command-group__title {
+  margin: 0 0 14px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.command-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+/* --- Command tile --- */
+.command-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 12px;
+  font-family: inherit;
+  color: var(--color-text);
+  text-align: center;
+  background-color: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    transform 0.08s ease,
+    box-shadow 0.15s ease;
+}
+
+.command-card:hover {
+  border-color: var(--color-border-hover);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.command-card:active {
+  transform: translateY(0);
+}
+
+.command-card:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.command-card__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+}
+
+.command-card__icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.command-card__label {
+  font-size: 13.5px;
+  font-weight: 500;
+}
+
+/* --- Icon tints per category (mirrors the sidebar nav palette) --- */
+.command-card__icon--access {
+  background-color: rgba(232, 33, 39, 0.15);
+  color: #ff5a5e;
+}
+
+.command-card__icon--trunk {
+  background-color: rgba(163, 163, 163, 0.15);
+  color: #c8c8c8;
+}
+
+.command-card__icon--charge {
+  background-color: rgba(33, 232, 100, 0.15);
+  color: #21e864;
+}
+
+.command-card__icon--signal {
+  background-color: rgba(232, 200, 33, 0.15);
+  color: #e8c821;
+}
+
+/* --- In-flight state (set by the JS) --- */
+.command-card.is-loading {
+  cursor: progress;
+  opacity: 0.55;
+}
+
+.command-card.is-loading .command-card__icon {
+  animation: command-pulse 0.9s ease-in-out infinite;
+}
+
+@keyframes command-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+/* --- Responsive --- */
+@media (max-width: 1100px) {
+  .vehicle-commands {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .vehicle-commands {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .command-hero {
+    padding: 16px 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .command-card,
+  .command-hero,
+  .command-card.is-loading .command-card__icon {
+    transition: none;
+    animation: none;
+  }
 }

--- a/www/_assets/js/vehicle-actions.js
+++ b/www/_assets/js/vehicle-actions.js
@@ -1,28 +1,32 @@
 // vehicle-actions.js — vehicle commands (issue #26).
 //
-// Each dashboard action button carries a data-action matching a route segment
-// (lock, unlock, honk, flash, trunk-front, ...). Clicking it POSTs to
-// /vehicle/<action> with the CSRF token read from the <meta name="csrf-token">
-// tag. The VIN is resolved server-side from the session (selected_vin), so it is
-// never sent from the browser.
+// Each command tile carries a data-action matching a route segment (lock,
+// unlock, honk, flash, trunk-front, ...). Clicking it POSTs to /vehicle/<action>
+// with the CSRF token read from the <meta name="csrf-token"> tag. The VIN is
+// resolved server-side from the session (selected_vin), so it is never sent
+// from the browser.
+//
+// The tile content (SVG pictogram + label) is preserved: instead of rewriting
+// button.textContent, the in-flight state is shown via an .is-loading class and
+// the shared [data-action-feedback] element. A re-entry guard (the .is-loading
+// check) prevents double submits without using the disabled attribute, which is
+// reserved for the "coming soon" placeholder tiles.
 
 function initVehicleActions() {
   const meta = document.querySelector('meta[name="csrf-token"]');
   const csrfToken = meta?.getAttribute('content') ?? '';
   const feedback = document.querySelector('[data-action-feedback]');
-  const buttons = document.querySelectorAll('.dashboard-actions [data-action]');
+  const buttons = document.querySelectorAll('.vehicle-commands [data-action]');
 
   buttons.forEach((button) => {
     button.addEventListener('click', async () => {
       const action = button.dataset.action;
-      if (!action) {
+      if (!action || button.classList.contains('is-loading')) {
         return;
       }
 
-      const originalLabel = button.textContent;
-      button.disabled = true;
-      button.textContent = 'Envoi…';
-      setFeedback(feedback, '', '');
+      button.classList.add('is-loading');
+      setFeedback(feedback, 'Envoi de la commande…', '');
 
       try {
         const response = await fetch('/vehicle/' + action, {
@@ -41,8 +45,7 @@ function initVehicleActions() {
       } catch {
         setFeedback(feedback, 'Échec de la commande, réessayez.', 'error');
       } finally {
-        button.disabled = false;
-        button.textContent = originalLabel;
+        button.classList.remove('is-loading');
       }
     });
   });


### PR DESCRIPTION
## Summary

Dashboard UI work on the `feat/dashboard-ui-commands` branch:

- **Sidebar nav** — the full-height sidebar becomes a floating sticky card (rounded, shadow, spacing from header/footer, more compact), on desktop and mobile.
- **Color harmonization** — the footer and the dashboard nav now use the header background; the area behind the nav uses the dashboard content background (no more vertical seam).
- **Vehicle command page** (`dashboard/vehicle`) — the flat text buttons become categorized pictogram tiles (Accès & sécurité, Coffres, Recharge, Signalement) with a full-width "Réveiller le véhicule" hero action. The command JS now toggles an `.is-loading` class instead of rewriting a button's content, so the SVG pictograms are preserved.
- **Change-vehicle link** — restyled from a bare link into a secondary header action button.
- **Uniform tiles** — every command tile shares the same height regardless of label wrapping.

## Test plan

- [x] Visual validation desktop + mobile (local preview rendering the real `control.php`)
- [x] Command click test: pictogram + label survive, `.is-loading` toggles, feedback shown
- [x] `getComputedStyle` checks for colors and tile heights (uniform 122px)
- [x] No JS console errors
- [x] Prettier conformant
