### PR TITLE
fix(dashboard): mobile nav overflow and battery page polish

### DIFF
--- a/private/Views/Charging/battery.php
+++ b/private/Views/Charging/battery.php
@@ -59,7 +59,7 @@ ob_start();
                 <input type="hidden" name="action" value="start">
                 <button type="submit" class="btn-success">Démarrer la charge</button>
               </form>
-              <form method="post" action="/charging/toggle" style="margin-top: 8px;">
+              <form method="post" action="/charging/toggle">
                 <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
                 <input type="hidden" name="action" value="stop">
                 <button type="submit" class="btn-primary">Arrêter la charge</button>
@@ -102,7 +102,7 @@ ob_start();
               <form method="post" action="/charging/amps">
                 <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
                 <label class="card-label" for="amps-input">Courant de charge (5 à 48 A)</label>
-                <input class="card-input" type="number" id="amps-input" name="amps" min="5" max="48" step="1"
+                <input class="precond-input" type="number" id="amps-input" name="amps" min="5" max="48" step="1"
                        value="16" required>
                 <button type="submit" class="btn-success">Appliquer</button>
               </form>

--- a/www/_assets/css/battery.css
+++ b/www/_assets/css/battery.css
@@ -261,6 +261,7 @@
 }
 
 .precond-input {
+  width: 100%;
   padding: 10px 12px;
   font-size: 14px;
   color: var(--color-text);
@@ -312,4 +313,34 @@
   margin: 0;
   font-size: 13px;
   color: var(--color-text-muted);
+}
+
+/* Card forms (charge, limit, amps): stacked controls with full-width buttons. */
+.card-details form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card-details .btn-success,
+.card-details .btn-primary {
+  width: 100%;
+  justify-content: center;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .precond-form {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 20px;
+  }
+
+  .precond-card {
+    padding: 14px 16px;
+  }
+
+  .temp-value {
+    min-width: 64px;
+  }
 }

--- a/www/_assets/css/dashboard.css
+++ b/www/_assets/css/dashboard.css
@@ -261,11 +261,23 @@
 
   .dashboard-navigation .nav-item {
     padding: 6px 4px;
+    /* The desktop width: 100% gives each item the intrinsic width of its label,
+       which pushes the row nav past small viewports. Share the row instead. */
+    width: auto;
+    flex: 1 1 0;
+    min-width: 0;
   }
 
   .dashboard-navigation .nav-item__icon {
     width: 34px;
     height: 34px;
+  }
+
+  .dashboard-navigation .nav-item__label {
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .dashboard-content {
@@ -287,5 +299,18 @@
 
   .card-value {
     font-size: 36px;
+  }
+}
+
+@media (max-width: 480px) {
+  /* Icons only: the labels do not fit five tabs on a phone.
+     Each .nav-item keeps its aria-label, so the nav stays accessible. */
+  .dashboard-navigation .nav-item__label {
+    display: none;
+  }
+
+  .dashboard-navigation .nav-item__icon {
+    width: 38px;
+    height: 38px;
   }
 }


### PR DESCRIPTION
## Summary

- **Toutes les pages dashboard débordaient horizontalement sur mobile** : les 5 onglets de la nav gardaient leur `width: 100%` desktop avec des labels insécables, ce qui forçait ~480 px de largeur minimale (mesuré : 130 px de débordement à 375 px). Les onglets se partagent désormais la barre (`flex: 1 1 0` + labels en ellipsis ≤ 768 px) et passent en icônes seules ≤ 480 px — les `aria-label` conservent l'accessibilité.
- **Page Batterie** : formulaire de planification en 1 colonne sur mobile, inputs pleine largeur, contrôles des cartes empilés avec boutons pleine largeur (rendu plus propre aussi en desktop), et l'input Ampérage passe sur `precond-input` (la classe `card-input` héritée du pattern clim n'existe dans aucune feuille de style).

## Test plan

- [x] Émulation mobile réelle 375 px : 0 px de débordement horizontal (130 px avant le fix) ; vérifié aussi à 768 px et 1280 px
- [x] validator.w3.org : 0 erreur / 0 warning ; console JS sans erreur
- [x] `composer test` : 135 tests verts ; Prettier conforme
