### PR TITLE
feat(charging): redesign the battery page

### DIFF
--- a/private/Views/Charging/battery.php
+++ b/private/Views/Charging/battery.php
@@ -3,16 +3,54 @@ use Teslapp\Models\Charging\ChargingPlanner;
 use Teslapp\Models\Shared\ValueObjects\DayOfWeek;
 
 /** @var string $vehicleId Vehicle public id, set by the rendering controller. */
+/** @var list<ChargingPlanner> $plans */
+/** @var array<string, mixed> $data Latest telemetry row (app.overview), may be empty. */
 
-$battery_level = $data['battery_level'] ?? 'N/A';
-$charge_enable = $data['charge_enable'] ?? false;
-$scheduled_charging_start_time = $data['scheduled_charging_start_time'] ?? null;
+$batteryLevelRaw = $data['battery_level'] ?? null;
+$batteryLevel = is_numeric($batteryLevelRaw)
+  ? (int) max(0, min(100, round((float) $batteryLevelRaw)))
+  : null;
+$chargeEnabled = (bool) ($data['charge_enable'] ?? false);
+
+// TIMESTAMP from the DB -> short readable label; keep the raw value if unparsable.
+$scheduledRaw = $data['scheduled_charging_start_time'] ?? null;
+$scheduledLabel = null;
+if (is_string($scheduledRaw) && $scheduledRaw !== '') {
+  try {
+    $scheduledLabel = (new DateTimeImmutable($scheduledRaw))->format('d/m · H:i');
+  } catch (Exception) {
+    $scheduledLabel = $scheduledRaw;
+  }
+}
+$lastSeenRaw = $data['last_seen_at'] ?? null;
+$lastSeenLabel = null;
+if (is_string($lastSeenRaw) && $lastSeenRaw !== '') {
+  try {
+    $lastSeenLabel = (new DateTimeImmutable($lastSeenRaw))->format('d/m · H:i');
+  } catch (Exception) {
+    $lastSeenLabel = $lastSeenRaw;
+  }
+}
+
+$gaugeModifier = '';
+if ($batteryLevel !== null && $batteryLevel <= 10) {
+  $gaugeModifier = ' battery-gauge--critical';
+} elseif ($batteryLevel !== null && $batteryLevel <= 20) {
+  $gaugeModifier = ' battery-gauge--low';
+}
+
 $csrf = $_SESSION['csrf_token'] ?? '';
 $title = 'Batterie — TeslApp';
 $description = 'Gérez la recharge de votre Tesla : charge, limite et fenêtres heures creuses.';
 $header = 'user';
 $extraCss = ['dashboard', 'battery'];
 $extraJs = ['battery'];
+
+// Leaflet (self-hosted vendor) powers the schedule location picker in the dialog.
+// `defer` keeps document order, so it executes before battery.js (also deferred).
+$headExtra =
+  '<link rel="stylesheet" href="/_assets/vendor/leaflet/leaflet.css">' .
+  '<script src="/_assets/vendor/leaflet/leaflet.js" defer></script>';
 
 ob_start();
 ?>
@@ -24,108 +62,145 @@ ob_start();
       <!-- Right Section -->
       <div class="dashboard-content">
         <h1 class="dashboard-title">Batterie</h1>
-        <div class="dashboard-grid">
-          <!-- Battery state -->
-          <div class="dashboard-card">
-            <div class="card-icon">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                   stroke="currentColor" class="size-6">
-                <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z" />
-              </svg>
+        <div class="battery-grid">
+          <!-- Battery state + immediate charge commands -->
+          <div class="dashboard-card battery-card">
+            <div class="battery-card__header">
+              <span class="battery-card__icon" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                     stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                        d="M21 10.5h.375c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125H21M3.75 18h15A2.25 2.25 0 0 0 21 15.75v-6a2.25 2.25 0 0 0-2.25-2.25h-15A2.25 2.25 0 0 0 1.5 9.75v6A2.25 2.25 0 0 0 3.75 18Z" />
+                </svg>
+              </span>
+              <h2 class="battery-card__title">État de la batterie</h2>
+              <span class="battery-chip<?= $chargeEnabled ? ' battery-chip--on' : '' ?>">
+                <span class="battery-chip__dot" aria-hidden="true"></span>
+                Charge <?= $chargeEnabled ? 'activée' : 'désactivée' ?>
+              </span>
             </div>
-            <h2 class="card-title">État batterie</h2>
-            <div class="card-content">
-              <p class="card-value"><?= e((string)$battery_level) ?><span> %</span></p>
-              <p class="card-label">Batterie actuelle</p>
-            </div>
-            <div class="card-details">
-              <p>Charge activée <span
-                  class="<?= $charge_enable ? 'status-on' : 'status-off' ?>"><?= $charge_enable ? 'Oui' : 'Non' ?></span>
+            <div class="battery-gauge<?= $gaugeModifier ?>">
+              <p class="battery-gauge__value">
+                <?= $batteryLevel !== null ? e((string) $batteryLevel) : 'N/A' ?><span> %</span>
               </p>
-              <p>Charge programmée <span><?= e($scheduled_charging_start_time ?? 'Non programmée') ?></span></p>
+              <div class="battery-gauge__track" role="img"
+                   aria-label="Niveau de batterie : <?= $batteryLevel !== null ? e((string) $batteryLevel) . ' %' : 'inconnu' ?>">
+                <div class="battery-gauge__fill" style="width: <?= $batteryLevel ?? 0 ?>%"></div>
+                <span class="battery-gauge__limit" id="gauge-limit" style="left: 80%"
+                      title="Limite de charge choisie"></span>
+              </div>
             </div>
-          </div>
-          <!-- Start / Stop charging -->
-          <div class="dashboard-card">
-            <div class="card-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                   stroke-linejoin="round" aria-hidden="true">
-                <path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z" />
-              </svg>
-            </div>
-            <h2 class="card-title">Charge</h2>
-            <div class="card-details">
+            <dl class="battery-meta">
+              <div class="battery-meta__item">
+                <dt>Charge programmée</dt>
+                <dd><?= $scheduledLabel !== null ? e($scheduledLabel) : 'Aucune' ?></dd>
+              </div>
+              <div class="battery-meta__item">
+                <dt>Dernière remontée</dt>
+                <dd><?= $lastSeenLabel !== null ? e($lastSeenLabel) : '—' ?></dd>
+              </div>
+            </dl>
+            <div class="battery-actions">
               <form method="post" action="/charging/toggle">
                 <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
                 <input type="hidden" name="vehicle_id" value="<?= e($vehicleId) ?>">
                 <input type="hidden" name="action" value="start">
-                <button type="submit" class="btn-success">Démarrer la charge</button>
+                <button type="submit" class="btn-success battery-actions__btn">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                       stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z" />
+                  </svg>
+                  Démarrer la charge
+                </button>
               </form>
               <form method="post" action="/charging/toggle">
                 <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
                 <input type="hidden" name="vehicle_id" value="<?= e($vehicleId) ?>">
                 <input type="hidden" name="action" value="stop">
-                <button type="submit" class="btn-primary">Arrêter la charge</button>
+                <button type="submit" class="btn-primary battery-actions__btn">Arrêter</button>
               </form>
             </div>
           </div>
-          <!-- Charge limit -->
-          <div class="dashboard-card">
-            <div class="card-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                   stroke-linejoin="round" aria-hidden="true">
-                <path d="M12 20V10M18 20V4M6 20v-4" />
-              </svg>
+          <!-- Charge settings: limit + amps -->
+          <div class="dashboard-card battery-card">
+            <div class="battery-card__header">
+              <span class="battery-card__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3M1 14h6M9 8h6M17 16h6" />
+                </svg>
+              </span>
+              <h2 class="battery-card__title">Réglages de charge</h2>
             </div>
-            <h2 class="card-title">Limite de charge</h2>
-            <div class="card-details">
-              <form method="post" action="/charging/limit" id="form-limit">
-                <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
-                <input type="hidden" name="vehicle_id" value="<?= e($vehicleId) ?>">
-                <input type="hidden" name="percent" value="80" id="limit-hidden">
-                <div class="temp-controls">
-                  <button type="button" class="btn-temp" id="limit-minus" aria-label="Diminuer la limite">−</button>
-                  <span class="temp-value"><span id="limit-display">80</span> %</span>
-                  <button type="button" class="btn-temp" id="limit-plus" aria-label="Augmenter la limite">+</button>
+            <form method="post" action="/charging/limit" class="battery-setting">
+              <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
+              <input type="hidden" name="vehicle_id" value="<?= e($vehicleId) ?>">
+              <input type="hidden" name="percent" value="80" id="limit-value">
+              <div class="battery-setting__head">
+                <span class="battery-setting__label">Limite de charge</span>
+                <span class="battery-setting__range">50 – 100 %</span>
+              </div>
+              <div class="battery-setting__controls">
+                <div class="battery-presets" role="group" aria-label="Limites rapides">
+                  <button type="button" class="battery-preset is-active" data-preset="limit" data-value="80">80 %</button>
+                  <button type="button" class="battery-preset" data-preset="limit" data-value="90">90 %</button>
+                  <button type="button" class="battery-preset" data-preset="limit" data-value="100">100 %</button>
                 </div>
-                <button type="submit" class="btn-success">Confirmer</button>
-              </form>
-            </div>
-          </div>
-          <!-- Charging amps -->
-          <div class="dashboard-card">
-            <div class="card-icon">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                   stroke-linejoin="round" aria-hidden="true">
-                <circle cx="12" cy="12" r="10" />
-                <path d="M12 6v6l4 2" />
-              </svg>
-            </div>
-            <h2 class="card-title">Ampérage</h2>
-            <div class="card-details">
-              <form method="post" action="/charging/amps">
-                <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
-                <input type="hidden" name="vehicle_id" value="<?= e($vehicleId) ?>">
-                <label class="card-label" for="amps-input">Courant de charge (5 à 48 A)</label>
-                <input class="precond-input" type="number" id="amps-input" name="amps" min="5" max="48" step="1"
-                       value="16" required>
-                <button type="submit" class="btn-success">Appliquer</button>
-              </form>
-            </div>
+                <div class="battery-stepper">
+                  <button type="button" class="battery-stepper__btn" id="limit-minus" aria-label="Diminuer la limite">−</button>
+                  <span class="battery-stepper__value"><span id="limit-display">80</span> %</span>
+                  <button type="button" class="battery-stepper__btn" id="limit-plus" aria-label="Augmenter la limite">+</button>
+                </div>
+                <button type="submit" class="btn-success battery-setting__apply">Appliquer</button>
+              </div>
+            </form>
+            <hr class="battery-divider">
+            <form method="post" action="/charging/amps" class="battery-setting">
+              <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
+              <input type="hidden" name="vehicle_id" value="<?= e($vehicleId) ?>">
+              <input type="hidden" name="amps" value="16" id="amps-value">
+              <div class="battery-setting__head">
+                <span class="battery-setting__label">Courant de charge</span>
+                <span class="battery-setting__range">5 – 48 A</span>
+              </div>
+              <div class="battery-setting__controls">
+                <div class="battery-presets" role="group" aria-label="Courants rapides">
+                  <button type="button" class="battery-preset" data-preset="amps" data-value="8">8 A</button>
+                  <button type="button" class="battery-preset is-active" data-preset="amps" data-value="16">16 A</button>
+                  <button type="button" class="battery-preset" data-preset="amps" data-value="32">32 A</button>
+                </div>
+                <div class="battery-stepper">
+                  <button type="button" class="battery-stepper__btn" id="amps-minus" aria-label="Diminuer le courant">−</button>
+                  <span class="battery-stepper__value"><span id="amps-display">16</span> A</span>
+                  <button type="button" class="battery-stepper__btn" id="amps-plus" aria-label="Augmenter le courant">+</button>
+                </div>
+                <button type="submit" class="btn-success battery-setting__apply">Appliquer</button>
+              </div>
+            </form>
           </div>
         </div>
         <!-- Scheduled Charging Section (off-peak windows) -->
         <section class="precond-section">
-          <h2 class="precond-section__title">Recharge programmée</h2>
-          <!-- List Schedules Section -->
-          <h3 class="precond-subtitle">Mes planifications</h3>
+          <div class="precond-section__header">
+            <div>
+              <h2 class="precond-section__title">Recharge programmée</h2>
+              <p class="precond-section__lead">
+                La voiture restreint sa charge à ces fenêtres lorsqu'elle est stationnée au lieu
+                indiqué — idéal pour les heures creuses.
+              </p>
+            </div>
+            <button type="button" class="precond-add" id="plan-add" aria-label="Ajouter une planification">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+            </button>
+          </div>
           <?php if (empty($plans)): ?>
-            <p class="precond-empty">Aucune planification pour le moment.</p>
+            <p class="precond-empty">Aucune planification pour le moment. Créez-en une avec le bouton « + ».</p>
           <?php else: ?>
             <ul class="precond-list">
               <?php foreach ($plans as $plan): ?>
-                <li class="precond-card">
+                <li class="precond-card<?= $plan->enabled ? '' : ' precond-card--off' ?>">
                   <div class="precond-card__info">
                     <span class="precond-card__time"><?= e($plan->activationHour) ?><?= $plan->deactivationHour !== null ? ' → ' . e($plan->deactivationHour) : '' ?></span>
                     <span class="precond-card__days"><?= e(
@@ -139,6 +214,19 @@ ob_start();
                     <?php endif; ?>
                   </div>
                   <div class="precond-card__actions">
+                    <button
+                      type="button"
+                      class="btn-soft precond-card__edit"
+                      data-plan-id="<?= e($plan->id) ?>"
+                      data-hour="<?= e($plan->activationHour) ?>"
+                      data-end="<?= e($plan->deactivationHour ?? '') ?>"
+                      data-days="<?= e(implode(',', $plan->dayIds())) ?>"
+                      data-memorize="<?= $plan->isMemorizedLongTerm() ? '1' : '0' ?>"
+                      data-enabled="<?= $plan->enabled ? '1' : '0' ?>"
+                      data-lat="<?= e($plan->location !== null ? (string) $plan->location->latitude : '') ?>"
+                      data-lon="<?= e($plan->location !== null ? (string) $plan->location->longitude : '') ?>"
+                      data-label="<?= e($plan->locationLabel ?? '') ?>"
+                    >Modifier</button>
                     <form method="post" action="/dashboard/<?= e($vehicleId) ?>/battery/plan/toggle">
                       <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
                       <input type="hidden" name="plan_id" value="<?= e($plan->id) ?>">
@@ -160,57 +248,86 @@ ob_start();
               <?php endforeach; ?>
             </ul>
           <?php endif; ?>
-          <!-- New Scheduling Form -->
-          <h3 class="precond-subtitle">Nouvelle planification</h3>
-          <form class="precond-form" method="post" action="/dashboard/<?= e($vehicleId) ?>/battery/plan/create">
-            <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
-            <p class="precond-hint">
-              La voiture limite sa charge à cette fenêtre lorsqu'elle est stationnée au lieu
-              indiqué — idéal pour les heures creuses. La fenêtre peut passer minuit.
-              <button type="button" class="btn-soft" id="offpeak-preset">Heures creuses (23h30 → 7h30)</button>
-            </p>
-            <div class="precond-field">
-              <label for="activation_hour">Début de la fenêtre</label>
-              <input class="precond-input" type="time" id="activation_hour" name="activation_hour" required>
+          <!-- Schedule dialog (create + edit). Opened by the "+" and "Modifier" buttons (battery.js). -->
+          <dialog class="precond-dialog" id="plan-dialog">
+            <div class="precond-dialog__header">
+              <h3 class="precond-dialog__title" id="plan-dialog-title">Nouvelle planification</h3>
+              <button type="button" class="precond-dialog__close" id="plan-dialog-close" aria-label="Fermer">&times;</button>
             </div>
-            <div class="precond-field">
-              <label for="deactivation_hour">Fin de la fenêtre <span class="precond-optional">(optionnel)</span></label>
-              <input class="precond-input" type="time" id="deactivation_hour" name="deactivation_hour">
-            </div>
-            <fieldset class="precond-days">
-              <legend>Jours</legend>
-              <div class="precond-days__grid">
-                <?php foreach (DayOfWeek::cases() as $day): ?>
-                  <label class="precond-check">
-                    <input type="checkbox" name="days[]" value="<?= e((string)$day->value) ?>">
-                    <?= e($day->labelFr()) ?>
-                  </label>
-                <?php endforeach; ?>
+            <!-- data-action-base lets battery.js switch the action between .../create and .../update. -->
+            <form
+              class="precond-form precond-form--dialog"
+              id="plan-form"
+              method="post"
+              action="/dashboard/<?= e($vehicleId) ?>/battery/plan/create"
+              data-action-base="/dashboard/<?= e($vehicleId) ?>/battery/plan"
+            >
+              <input type="hidden" name="csrf_token" value="<?= e($csrf) ?>">
+              <!-- Enabled by battery.js in edit mode only (a disabled input is not submitted). -->
+              <input type="hidden" name="plan_id" id="plan_id" disabled>
+              <div class="precond-field">
+                <label for="activation_hour">Début de la fenêtre</label>
+                <input class="precond-input" type="time" id="activation_hour" name="activation_hour" required>
               </div>
-            </fieldset>
-            <label class="precond-check">
-              <input type="checkbox" name="memorize" value="1">
-              Mémoriser (planification récurrente)
-            </label>
-            <label class="switch">
-              <input type="checkbox" name="enabled" value="1" checked>
-              <span class="switch__track"><span class="switch__knob"></span></span>
-              Activée
-            </label>
-            <div class="precond-field">
-              <label for="latitude">Latitude <span class="precond-optional">(requis pour synchroniser avec le véhicule)</span></label>
-              <input class="precond-input" type="number" step="any" id="latitude" name="latitude">
-            </div>
-            <div class="precond-field">
-              <label for="longitude">Longitude <span class="precond-optional">(requis pour synchroniser avec le véhicule)</span></label>
-              <input class="precond-input" type="number" step="any" id="longitude" name="longitude">
-            </div>
-            <div class="precond-field">
-              <label for="location_label">Lieu <span class="precond-optional">(optionnel)</span></label>
-              <input class="precond-input" type="text" id="location_label" name="location_label">
-            </div>
-            <button class="btn-success" type="submit">Créer la planification</button>
-          </form>
+              <div class="precond-field">
+                <label for="deactivation_hour">Fin de la fenêtre <span class="precond-optional">(optionnel)</span></label>
+                <input class="precond-input" type="time" id="deactivation_hour" name="deactivation_hour">
+              </div>
+              <p class="precond-window-hint">
+                La fenêtre peut passer minuit.
+                <button type="button" class="btn-soft" id="offpeak-preset">Heures creuses (23h30 → 7h30)</button>
+              </p>
+              <fieldset class="precond-days">
+                <legend>Jours</legend>
+                <div class="precond-days__grid">
+                  <?php foreach (DayOfWeek::cases() as $day): ?>
+                    <label class="precond-check">
+                      <input type="checkbox" name="days[]" value="<?= e((string) $day->value) ?>">
+                      <?= e($day->labelFr()) ?>
+                    </label>
+                  <?php endforeach; ?>
+                </div>
+              </fieldset>
+              <div class="precond-switches">
+                <label class="switch">
+                  <input type="checkbox" name="memorize" value="1">
+                  <span class="switch__track"><span class="switch__knob"></span></span>
+                  Mémoriser (récurrente)
+                </label>
+                <label class="switch">
+                  <input type="checkbox" name="enabled" value="1" checked>
+                  <span class="switch__track"><span class="switch__knob"></span></span>
+                  Activée
+                </label>
+              </div>
+              <div class="precond-map-block">
+                <label for="location_label">
+                  Lieu d'activation
+                  <span class="precond-optional">(optionnel — requis pour synchroniser avec le véhicule)</span>
+                </label>
+                <div class="precond-map" id="plan-map" role="application" aria-label="Carte de sélection du lieu"></div>
+                <div class="precond-address">
+                  <input
+                    class="precond-input precond-address__input"
+                    type="text"
+                    id="location_label"
+                    name="location_label"
+                    placeholder="Adresse (ou cliquez sur la carte)"
+                    autocomplete="off"
+                  >
+                  <button type="button" class="btn-soft precond-address__search" id="plan-address-search">Rechercher</button>
+                </div>
+                <p class="precond-map__hint">
+                  Cliquez sur la carte ou saisissez une adresse puis « Rechercher » — les deux restent
+                  synchronisés. Sans lieu, la planification reste locale (non envoyée au véhicule).
+                </p>
+                <p class="precond-form__error" id="plan-form-error" role="alert" hidden></p>
+              </div>
+              <input type="hidden" name="latitude" id="latitude">
+              <input type="hidden" name="longitude" id="longitude">
+              <button class="btn-success" type="submit" id="plan-submit">Créer la planification</button>
+            </form>
+          </dialog>
         </section>
       </div>
     </div>

--- a/www/_assets/css/battery.css
+++ b/www/_assets/css/battery.css
@@ -1,22 +1,288 @@
-/* Battery page (dashboard/battery).
-   Planner styles are duplicated from ac.css on purpose: each page ships its own
-   stylesheet (dashboard.css, ac.css, vehicle-actions.css…), with no shared import. */
+/* Battery page (dashboard/{vehicleId}/battery).
+   Planner/dialog styles are duplicated from ac.css on purpose: each page ships its
+   own stylesheet (dashboard.css, ac.css, vehicle-actions.css…), with no shared import. */
 
-.temp-controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  margin: 12px 0;
+/* ---- Page layout: two compact cards side by side ---- */
+
+.battery-grid {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr;
+  gap: 20px;
 }
 
-.btn-temp {
+/* Compact card: tighter padding than .dashboard-card, inline icon + title header. */
+.battery-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+}
+
+.battery-card__header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.battery-card__icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  font-size: 20px;
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  color: #21c55e;
+  background-color: rgba(34, 197, 94, 0.14);
+  border-radius: 50%;
+}
+
+.battery-card__icon svg {
+  width: 19px;
+  height: 19px;
+}
+
+.battery-card__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+/* Charge state chip, pinned to the right of the header. */
+.battery-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-left: auto;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+}
+
+.battery-chip__dot {
+  width: 7px;
+  height: 7px;
+  background-color: var(--color-text-muted);
+  border-radius: 50%;
+}
+
+.battery-chip--on {
+  color: #4ade80;
+  background-color: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.35);
+}
+
+.battery-chip--on .battery-chip__dot {
+  background-color: #22c55e;
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.8);
+}
+
+/* ---- Battery gauge ---- */
+
+.battery-gauge {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.battery-gauge__value {
+  margin: 0;
+  font-size: 42px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -1px;
+  color: var(--color-text);
+}
+
+.battery-gauge__value span {
+  font-size: 18px;
+  font-weight: 400;
+  letter-spacing: 0;
+  color: var(--color-text-secondary);
+}
+
+.battery-gauge__track {
+  position: relative;
+  height: 14px;
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+}
+
+.battery-gauge__fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #15803d, #22c55e);
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+
+.battery-gauge--low .battery-gauge__fill {
+  background: linear-gradient(90deg, #b45309, #f59e0b);
+}
+
+.battery-gauge--critical .battery-gauge__fill {
+  background: linear-gradient(90deg, #b91c1c, #ef4444);
+}
+
+/* Charge-limit marker; battery.js moves it when the limit stepper changes. */
+.battery-gauge__limit {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
+  margin-left: -1px;
+  background-color: var(--color-text-secondary);
+  border-radius: 1px;
+  transition: left 0.25s ease;
+}
+
+/* ---- Key/value rows under the gauge ---- */
+
+.battery-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding-top: 14px;
+  border-top: 1px solid var(--color-border);
+}
+
+.battery-meta__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.battery-meta__item dt {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.battery-meta__item dd {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+/* ---- Start / stop charge buttons ---- */
+
+.battery-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: auto; /* keep the buttons bottom-aligned when the grid stretches the card */
+}
+
+.battery-actions form {
+  display: flex;
+  flex: 1;
+}
+
+.battery-actions__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.battery-actions__btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ---- Charge settings (limit + amps) ---- */
+
+.battery-setting {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.battery-setting__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.battery-setting__label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.battery-setting__range {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.battery-setting__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.battery-presets {
+  display: flex;
+  gap: 6px;
+}
+
+/* Quick-value chip; battery.js toggles .is-active to mirror the stepper value. */
+.battery-preset {
+  padding: 7px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.battery-preset:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-hover);
+}
+
+.battery-preset.is-active {
+  color: #000000;
+  background-color: #ffffff;
+  border-color: #6c6c6c;
+}
+
+.battery-preset:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.battery-stepper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.battery-stepper__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 18px;
   font-weight: 600;
   color: var(--color-text);
   background-color: var(--color-bg-secondary);
@@ -26,20 +292,47 @@
   transition: background-color 0.15s ease;
 }
 
-.btn-temp:hover {
+.battery-stepper__btn:hover {
   background-color: var(--color-bg-hover);
 }
 
-.temp-value {
-  font-size: 24px;
-  font-weight: 700;
-  color: var(--color-text);
-  min-width: 80px;
-  text-align: center;
+.battery-stepper__btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
+.battery-stepper__value {
+  min-width: 58px;
+  font-size: 16px;
+  font-weight: 700;
+  text-align: center;
+  color: var(--color-text);
+}
+
+.battery-setting__apply {
+  margin-left: auto; /* right-aligned, under the stepper when the controls wrap */
+  padding: 8px 16px;
+  font-size: 13px;
+}
+
+.battery-divider {
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--color-border);
+}
+
+/* ---- Scheduled charging section ---- */
+
 .precond-section {
-  margin-top: 40px;
+  margin-top: 36px;
+}
+
+.precond-section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
 }
 
 .precond-section__title {
@@ -49,13 +342,44 @@
   color: var(--color-text);
 }
 
-.precond-subtitle {
+.precond-section__lead {
+  margin: 0;
+  max-width: 560px;
   font-size: 13px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin: 28px 0 12px;
+  color: var(--color-text-muted);
+}
+
+.precond-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  color: #ffffff;
+  background-color: var(--color-primary);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.precond-add svg {
+  width: 18px;
+  height: 18px;
+}
+
+.precond-add:hover {
+  opacity: 0.85;
+  transform: scale(1.05);
+}
+
+.precond-add:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .precond-optional {
@@ -67,7 +391,7 @@
 .precond-empty {
   font-size: 14px;
   color: var(--color-text-secondary);
-  padding: 16px 0;
+  padding: 8px 0;
 }
 
 .precond-list {
@@ -92,10 +416,16 @@
   box-shadow: var(--shadow-card);
 }
 
+/* Disabled schedule: fade the description, keep the actions readable. */
+.precond-card--off .precond-card__info {
+  opacity: 0.5;
+}
+
 .precond-card__info {
   display: flex;
   flex-direction: column;
   gap: 3px;
+  transition: opacity 0.2s ease;
 }
 
 .precond-card__time {
@@ -119,6 +449,8 @@
   align-items: center;
   gap: 10px;
 }
+
+/* ---- Switches ---- */
 
 .switch {
   display: inline-flex;
@@ -201,6 +533,8 @@
   transform: translateX(20px);
 }
 
+/* ---- Soft / danger buttons ---- */
+
 .btn-soft {
   padding: 6px 12px;
   font-size: 13px;
@@ -229,6 +563,8 @@
   background-color: rgba(239, 68, 68, 0.08);
 }
 
+/* ---- Schedule dialog (create + edit) ---- */
+
 .precond-form {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -243,7 +579,6 @@
 .precond-form .precond-days,
 .precond-form .precond-check,
 .precond-form .switch,
-.precond-form .precond-hint,
 .precond-form button[type='submit'] {
   grid-column: 1 / -1;
 }
@@ -276,6 +611,18 @@
   border-color: var(--color-primary);
 }
 
+/* Off-peak helper line: explanation + one-click window preset. */
+.precond-window-hint {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
 .precond-days {
   border: none;
   padding: 0;
@@ -295,52 +642,189 @@
   gap: 10px;
 }
 
+/* Day picker chips: the checkbox is visually hidden, the label is the pill. */
 .precond-check {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  padding: 8px 16px;
   font-size: 14px;
   color: var(--color-text-secondary);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.precond-check:hover {
+  border-color: var(--color-border-hover);
+}
+
+.precond-check input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+}
+
+.precond-check:has(input:checked) {
+  color: #ffffff;
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.precond-check:has(input:focus-visible) {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.precond-dialog {
+  /* The global reset zeroes margins, killing the UA's auto-centering of modal dialogs. */
+  margin: auto;
+  width: min(680px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background-color: var(--color-bg-card);
+  color: var(--color-text);
+  box-shadow: var(--shadow-card);
+}
+
+.precond-dialog::backdrop {
+  background: rgba(15, 18, 25, 0.55);
+}
+
+.precond-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 0;
+}
+
+.precond-dialog__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.precond-dialog__close {
+  width: 32px;
+  height: 32px;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: 8px;
   cursor: pointer;
 }
 
-/* Off-peak helper line: explanation + one-click window preset. */
-.precond-hint {
+.precond-dialog__close:hover {
+  background-color: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.precond-form--dialog {
+  gap: 18px 24px;
+  padding: 20px 24px 24px;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+.precond-form--dialog input[type='time'] {
+  max-width: 220px;
+}
+
+.precond-form--dialog button[type='submit'] {
+  padding: 12px;
+  font-size: 15px;
+}
+
+.precond-switches {
+  grid-column: 1 / -1;
   display: flex;
-  align-items: center;
   flex-wrap: wrap;
-  gap: 12px;
-  margin: 0;
+  gap: 16px 32px;
+}
+
+.precond-map-block {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.precond-map-block > label {
   font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.precond-map {
+  position: relative;
+  z-index: 0;
+  height: 260px;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+}
+
+.precond-address {
+  display: flex;
+  gap: 8px;
+}
+
+.precond-address__input {
+  flex: 1;
+}
+
+.precond-map__hint {
+  margin: 0;
+  font-size: 12px;
   color: var(--color-text-muted);
 }
 
-/* Card forms (charge, limit, amps): stacked controls with full-width buttons. */
-.card-details form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.precond-form__error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-error);
 }
 
-.card-details .btn-success,
-.card-details .btn-primary {
-  width: 100%;
-  justify-content: center;
-}
+/* ---- Responsive ---- */
 
-/* Responsive */
-@media (max-width: 768px) {
-  .precond-form {
+@media (max-width: 1024px) {
+  .battery-grid {
     grid-template-columns: 1fr;
-    gap: 16px;
+  }
+}
+
+/* Same mobile breakpoint as dashboard.css, so the dialog collapses with its page layout. */
+@media (max-width: 768px) {
+  .battery-card {
     padding: 20px;
+  }
+
+  .battery-gauge__value {
+    font-size: 36px;
+  }
+
+  .precond-form--dialog {
+    grid-template-columns: 1fr;
+  }
+
+  .precond-map {
+    height: 220px;
   }
 
   .precond-card {
     padding: 14px 16px;
-  }
-
-  .temp-value {
-    min-width: 64px;
   }
 }

--- a/www/_assets/js/battery.js
+++ b/www/_assets/js/battery.js
@@ -1,30 +1,276 @@
-const limitDisplay = document.getElementById('limit-display');
-const limitHidden = document.getElementById('limit-hidden');
-const limitMinus = document.getElementById('limit-minus');
-const limitPlus = document.getElementById('limit-plus');
+/* Battery page: steppers + quick presets for the charge settings, the gauge limit
+   marker, and the charging-schedule dialog with its Leaflet location picker. */
 
-/* Charge limit stepper: 5% steps, clamped to Tesla's [50, 100] range */
-limitMinus.addEventListener('click', () => {
-  let val = parseInt(limitHidden.value, 10);
-  if (val > 50) {
-    val -= 5;
-    limitHidden.value = val;
-    limitDisplay.textContent = val;
+/* ---- Steppers + quick presets (charge limit, charging amps) ---- */
+
+function initStepper({ name, min, max, step, onChange }) {
+  const hidden = document.getElementById(`${name}-value`);
+  const display = document.getElementById(`${name}-display`);
+  const presets = [...document.querySelectorAll(`.battery-preset[data-preset="${name}"]`)];
+
+  function set(value) {
+    const clamped = Math.min(max, Math.max(min, value));
+    hidden.value = clamped;
+    display.textContent = clamped;
+    presets.forEach((button) => {
+      button.classList.toggle('is-active', Number(button.dataset.value) === clamped);
+    });
+    if (onChange) onChange(clamped);
   }
+
+  document.getElementById(`${name}-minus`).addEventListener('click', () => {
+    set(parseInt(hidden.value, 10) - step);
+  });
+  document.getElementById(`${name}-plus`).addEventListener('click', () => {
+    set(parseInt(hidden.value, 10) + step);
+  });
+  presets.forEach((button) => {
+    button.addEventListener('click', () => set(Number(button.dataset.value)));
+  });
+}
+
+const gaugeLimit = document.getElementById('gauge-limit');
+
+/* Charge limit: 5% steps, clamped to Tesla's [50, 100] range; mirrors onto the gauge marker. */
+initStepper({
+  name: 'limit',
+  min: 50,
+  max: 100,
+  step: 5,
+  onChange: (value) => {
+    if (gaugeLimit) gaugeLimit.style.left = `${value}%`;
+  },
 });
 
-limitPlus.addEventListener('click', () => {
-  let val = parseInt(limitHidden.value, 10);
-  if (val < 100) {
-    val += 5;
-    limitHidden.value = val;
-    limitDisplay.textContent = val;
+/* Charging amps: 1A steps, clamped to Tesla's [5, 48] range. */
+initStepper({ name: 'amps', min: 5, max: 48, step: 1 });
+
+/* ---- Charging schedules: create/edit dialog + Leaflet location picker ---- */
+
+const dialog = document.getElementById('plan-dialog');
+
+if (dialog) {
+  const form = document.getElementById('plan-form');
+  const dialogTitle = document.getElementById('plan-dialog-title');
+  const submitBtn = document.getElementById('plan-submit');
+  const planIdInput = document.getElementById('plan_id');
+  const hourInput = document.getElementById('activation_hour');
+  const endInput = document.getElementById('deactivation_hour');
+  const memorizeInput = form.querySelector('input[name="memorize"]');
+  const enabledInput = form.querySelector('input[name="enabled"]');
+  const dayInputs = [...form.querySelectorAll('input[name="days[]"]')];
+  const latInput = document.getElementById('latitude');
+  const lonInput = document.getElementById('longitude');
+  const addressInput = document.getElementById('location_label');
+  const errorBox = document.getElementById('plan-form-error');
+
+  const FRANCE_CENTER = [46.6, 2.45];
+
+  let map = null;
+  let marker = null;
+  // Bumped on each geocode request so stale responses are ignored.
+  let geocodeSeq = 0;
+  let reverseTimer = null;
+  // Set when the user types in the address field.
+  let addressDirty = false;
+  let submitting = false;
+
+  function showError(message) {
+    errorBox.textContent = message;
+    errorBox.hidden = false;
   }
-});
 
-/* Pre-fills the charging window with a typical off-peak tariff window */
-const offpeakPreset = document.getElementById('offpeak-preset');
-offpeakPreset.addEventListener('click', () => {
-  document.getElementById('activation_hour').value = '23:30';
-  document.getElementById('deactivation_hour').value = '07:30';
-});
+  function clearError() {
+    errorBox.hidden = true;
+  }
+
+  /* The map is created once, on first dialog opening (it needs a laid-out container). */
+  function ensureMap() {
+    if (map) return;
+    map = L.map('plan-map').setView(FRANCE_CENTER, 5);
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map);
+    map.on('click', (e) => {
+      const point = e.latlng.wrap();
+      setLocation(point.lat, point.lng, { reverseGeocode: true });
+    });
+  }
+
+  /* Map -> form: place the marker, fill the hidden coordinates, optionally resolve the address. */
+  function setLocation(lat, lon, { reverseGeocode = false } = {}) {
+    latInput.value = lat.toFixed(6);
+    lonInput.value = lon.toFixed(6);
+    if (marker) {
+      marker.setLatLng([lat, lon]);
+    } else {
+      marker = L.marker([lat, lon], { draggable: true }).addTo(map);
+      marker.on('dragend', () => {
+        const point = marker.getLatLng().wrap();
+        setLocation(point.lat, point.lng, { reverseGeocode: true });
+      });
+    }
+    clearError();
+    if (reverseGeocode) {
+      // Keep the field readable until the address resolves.
+      addressInput.value = `${lat.toFixed(5)}, ${lon.toFixed(5)}`;
+      const seq = ++geocodeSeq;
+      clearTimeout(reverseTimer);
+      // Wait for the marker to settle before hitting Nominatim.
+      reverseTimer = setTimeout(() => {
+        fetch(`/geocode/reverse?lat=${lat}&lon=${lon}`, {
+          headers: { Accept: 'application/json' },
+        })
+          .then((response) => (response.ok ? response.json() : null))
+          .then((data) => {
+            if (seq === geocodeSeq && data?.label) addressInput.value = data.label;
+          })
+          .catch(() => {});
+      }, 400);
+    }
+  }
+
+  function clearLocation() {
+    latInput.value = '';
+    lonInput.value = '';
+    if (marker) {
+      marker.remove();
+      marker = null;
+    }
+  }
+
+  /* Form -> map: geocode the typed address, then place the marker and recenter. */
+  async function searchAddress() {
+    const query = addressInput.value.trim();
+    if (query === '') {
+      showError('Saisissez une adresse ou cliquez sur la carte.');
+      return false;
+    }
+    const seq = ++geocodeSeq;
+    try {
+      const response = await fetch(`/geocode?q=${encodeURIComponent(query)}`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (seq !== geocodeSeq) return false;
+      if (!response.ok) {
+        showError('Adresse introuvable : précisez (rue, ville…) ou cliquez sur la carte.');
+        return false;
+      }
+      const data = await response.json();
+      if (seq !== geocodeSeq) return false;
+      setLocation(data.lat, data.lon, { reverseGeocode: false });
+      addressInput.value = data.label;
+      map.setView([data.lat, data.lon], 15);
+      return true;
+    } catch {
+      if (seq === geocodeSeq) showError('Recherche impossible pour le moment, réessayez.');
+      return false;
+    }
+  }
+
+  /* Opens the dialog in create mode (planData = null) or edit mode (planData = button dataset). */
+  function openDialog(planData) {
+    // Drop any geocode response still in flight.
+    geocodeSeq++;
+    clearTimeout(reverseTimer);
+    addressDirty = false;
+    form.reset();
+    clearError();
+    clearLocation();
+    if (planData) {
+      dialogTitle.textContent = 'Modifier la planification';
+      submitBtn.textContent = 'Enregistrer';
+      form.action = `${form.dataset.actionBase}/update`;
+      planIdInput.disabled = false;
+      planIdInput.value = planData.planId;
+      hourInput.value = planData.hour;
+      endInput.value = planData.end;
+      const days = planData.days.split(',').filter(Boolean);
+      dayInputs.forEach((input) => {
+        input.checked = days.includes(input.value);
+      });
+      memorizeInput.checked = planData.memorize === '1';
+      enabledInput.checked = planData.enabled === '1';
+      addressInput.value = planData.label;
+    } else {
+      dialogTitle.textContent = 'Nouvelle planification';
+      submitBtn.textContent = 'Créer la planification';
+      form.action = `${form.dataset.actionBase}/create`;
+      planIdInput.disabled = true;
+      planIdInput.value = '';
+      enabledInput.checked = true;
+    }
+    dialog.showModal();
+    // Leaflet can only size the map once the dialog is rendered.
+    requestAnimationFrame(() => {
+      ensureMap();
+      map.invalidateSize();
+      if (planData && planData.lat !== '' && planData.lon !== '') {
+        const lat = Number(planData.lat);
+        const lon = Number(planData.lon);
+        setLocation(lat, lon, { reverseGeocode: false });
+        map.setView([lat, lon], 15);
+      } else {
+        map.setView(FRANCE_CENTER, 5);
+      }
+    });
+  }
+
+  document.getElementById('plan-add').addEventListener('click', () => openDialog(null));
+  document.querySelectorAll('.precond-card__edit').forEach((button) => {
+    button.addEventListener('click', () => openDialog(button.dataset));
+  });
+  document.getElementById('plan-dialog-close').addEventListener('click', () => dialog.close());
+  dialog.addEventListener('click', (e) => {
+    // A click on the native backdrop targets the <dialog> element itself.
+    if (e.target === dialog) dialog.close();
+  });
+
+  /* Pre-fills the charging window with a typical off-peak tariff window. */
+  document.getElementById('offpeak-preset').addEventListener('click', () => {
+    hourInput.value = '23:30';
+    endInput.value = '07:30';
+  });
+
+  document.getElementById('plan-address-search').addEventListener('click', searchAddress);
+  addressInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      searchAddress();
+    }
+  });
+  addressInput.addEventListener('input', () => {
+    // Typing invalidates the stored coordinates.
+    addressDirty = true;
+    geocodeSeq++;
+    clearLocation();
+  });
+
+  form.addEventListener('submit', async (e) => {
+    // Location already resolved, nothing to do here.
+    if (latInput.value !== '' && lonInput.value !== '') return;
+
+    // No location at all: fine, the schedule simply stays local (not pushed to the car).
+    if (addressInput.value.trim() === '') return;
+
+    // A typed address is not geocoded yet: resolve it before letting the form go.
+    e.preventDefault();
+    if (submitting) return;
+
+    if (!addressDirty) {
+      // Never geocode a stored label behind the user's back.
+      showError('Vérifiez le lieu : lancez la recherche, cliquez sur la carte, ou videz le champ.');
+      return;
+    }
+
+    submitting = true;
+    submitBtn.disabled = true;
+    try {
+      if (await searchAddress()) form.requestSubmit();
+    } finally {
+      submitting = false;
+      submitBtn.disabled = false;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Replace the four oversized cards with two compact ones: a battery state card (visual gauge with a charge-limit marker, charge-enabled chip, formatted schedule info, start/stop buttons) and a charge settings card (quick presets + steppers for the charge limit and amps).
- Replace the always-open inline schedule form (manual latitude/longitude fields) with the dialog pattern from the climate page: Leaflet location picker synced with the geocoding endpoints, optional geofence, off-peak window preset (23:30 → 07:30).
- Add the missing « Modifier » button on schedules, wired to the existing `battery/plan/update` route; disabled schedules are now dimmed in the list.
- No backend change: view, CSS and JS only.

## Test plan

- `composer phpstan` (0 error), `php -l`, Prettier check.
- W3C Nu validator: 0 error / 0 warning on the rendered page; W3C CSS validator: 0 error.
- Manually tested on the local Docker bench against the real DB, with `TESLA_COMMANDS_DRY_RUN=true` verified in the container beforehand: the four immediate commands (start/stop/limit/amps) each return 302 + their flash message and log `command not sent: …/charge_start|charge_stop|set_charge_limit|set_charging_amps` — nothing reaches the vehicle.
- Full schedule cycle verified: create → toggle off/on → update → delete (no Tesla call without a geofence), DB left clean afterwards.
- Desktop 1440px + mobile 375px screenshots checked; browser console empty.